### PR TITLE
Create COPYRIGHT.md

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,19 @@
+Hello,
+
+As your repository does not allow the creation of Issues and we have no other means of contacting you, this is how we decided to approach you 
+on behalf of the community at js13kGames in general, and the author of this game - Igor Estevao - in particular.
+
+The repository you forked and then modified, i.e. https://github.com/IgorFIE/the-knighting-of-sr-isaac, does not contain nor reference a license in any form whatsoever. 
+While, per GitHub's terms, you are allowed to fork such a repository - you are not actually allowed to do (basically) anything else with the code, since you were not granted the 
+rights to do so. In particular, you were not allowed to modify the code and publish those modifications, let alone publish them with your own chosen license while simultaneously 
+removing references to the actual author and copyright owner (as you did in `package.json`). This technically constitutes theft of intellectual property.
+
+However, we believe this was done not in bad faith but on the misconstrued assumption that code published on GitHub is falls under some sort of generic open source license by default, 
+where it does not. 
+
+In the spirit of Open Source we ask you to respect the author's rights and entirely unpublish the code in question from every place you have published it at, no later than within 
+7 days for this repository and within 14 days for every other location. If others have further published the code in question believing they are allowed to do so based on the license 
+you illegally attached, we also ask you to follow up to those people and ask them to unpublish the code, in order to mitigate the damage your actions caused.
+
+Best regards,
+The js13kGames community


### PR DESCRIPTION
**Edited**:
No longer relevant - we - along with Igor Estevao, i.e. the author - noticed his mistake in retaining the `license: "ISC"` declaration within `package.json`.

Bottom line being: we believe both of you made mistakes. Igor in not removing that note, and you in assuming that note is equal to an actual license.

Again, in good faith and within the spirit of Open Source, I hope this gets resolved amicably.

Best regards.